### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,46 +110,46 @@ FoxMetrics.prototype.track = function(track) {
 };
 
 /**
- * Viewed product.
+ * Product viewed.
  *
  * @api private
  * @param {Track} track
  */
 
-FoxMetrics.prototype.viewedProduct = function(track) {
+FoxMetrics.prototype.productViewed = function(track) {
   ecommerce('productview', track);
 };
 
 /**
- * Removed product.
+ * Product Removed.
  *
  * @api private
  * @param {Track} track
  */
 
-FoxMetrics.prototype.removedProduct = function(track) {
+FoxMetrics.prototype.productRemoved = function(track) {
   ecommerce('removecartitem', track);
 };
 
 /**
- * Added product.
+ * Product Added.
  *
  * @api private
  * @param {Track} track
  */
 
-FoxMetrics.prototype.addedProduct = function(track) {
+FoxMetrics.prototype.productAdded = function(track) {
   ecommerce('cartitem', track);
 };
 
 /**
- * Completed Order.
+ * Order Completed.
  *
  * @api private
  * @param {Track} track
  */
 
-FoxMetrics.prototype.completedOrder = function(track) {
+FoxMetrics.prototype.orderCompleted = function(track) {
   var orderId = track.orderId();
 
   // transaction

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-foxmetrics#readme",
   "dependencies": {
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
     "global-queue": "^1.0.1",
     "segmentio-facade": "^3.0.3"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -220,8 +220,8 @@ describe('FoxMetrics', function() {
         analytics.stub(window._fxm, 'push');
       });
 
-      it('should track viewed product', function() {
-        analytics.track('viewed product', {
+      it('should track product viewed', function() {
+        analytics.track('product viewed', {
           sku: 'f84d349b',
           name: 'my-product',
           category: 'category'
@@ -235,8 +235,8 @@ describe('FoxMetrics', function() {
         ]);
       });
 
-      it('should track added product', function() {
-        analytics.track('added product', {
+      it('should track product added', function() {
+        analytics.track('product added', {
           id: 'c1ec1864',
           name: 'my-product',
           category: 'category'
@@ -250,8 +250,8 @@ describe('FoxMetrics', function() {
         ]);
       });
 
-      it('should track removed product', function() {
-        analytics.track('removed product', {
+      it('should track product removed', function() {
+        analytics.track('product removed', {
           sku: 'c1ec1864',
           name: 'my-product'
         });
@@ -264,8 +264,8 @@ describe('FoxMetrics', function() {
         ]);
       });
 
-      it('should track completed order', function() {
-        analytics.track('completed order', {
+      it('should track order completed', function() {
+        analytics.track('order completed', {
           orderId: '3723ee8a',
           total: 300,
           tax: 10,


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.
